### PR TITLE
Changed tag from `v1.0.0` to `1.0.0`

### DIFF
--- a/docs/01-getting-started/setup-docr.md
+++ b/docs/01-getting-started/setup-docr.md
@@ -52,12 +52,12 @@ In this section, you will push to DOCR the first version (`v1.0.0`) of the [Onli
 
     ```shell
     export REPO_PREFIX="registry.digitalocean.com/microservices-demo"
-    export TAG="v1.0.0"
+    export TAG="1.0.0"
 
     ./release-scripts/make-docker-images.sh
     ```
 
     !!!info
-        You will be pushing an initial release first to DOCR - `v1.0.0`, and use that to deploy to the `staging` and `production` environments in the upcoming sections. Later on, GitHub Actions will take care of building, tagging and pushing images to `DOCR`.
+        You will be pushing an initial release first to DOCR - `1.0.0`, and use that to deploy to the `staging` and `production` environments in the upcoming sections. Later on, GitHub Actions will take care of building, tagging and pushing images to `DOCR`.
 
 Next, you will setup the development environment and deploy the `microservices-demo` application to the associated DOKS cluster, as well as setting up `ingress` and `monitoring`.


### PR DESCRIPTION
The various `kustomization.yaml` files in `kustomize` [here](https://github.com/digitalocean/kubernetes-sample-apps/tree/master/microservices-demo/kustomize) refer to the tag `1.0.0` which does not exist at that time since the tags have been created are tagged with `v1.0.0.`. This causes the following error when pulling images:
```
Failed to pull image "registry.digitalocean.com/MY_REGISTRY/cartservice:1.0.0": rpc error: code = NotFound desc = failed to pull and unpack image "registry.digitalocean.com/MY_REGISTRY/cartservice:1.0.0": failed to resolve reference "registry.digitalocean.com/MY_REGISTRY/cartservice:1.0.0": registry.digitalocean.com/MY_REGISTRY/cartservice:1.0.0: not found
```
Changing the various `newTag` fields from `newTag: 1.0.0` to `newTag: v1.0.0` would work too but I'd prefer tagging without `v` prefix.